### PR TITLE
Expose ramda functions as default on window

### DIFF
--- a/repl/lib/js/main.js
+++ b/repl/lib/js/main.js
@@ -9,3 +9,7 @@ const lift3 = ramdaFantasy.lift3;
 const Maybe = ramdaFantasy.Maybe;
 const Tuple = ramdaFantasy.Tuple;
 const Reader = ramdaFantasy.Reader;
+
+const _window = {}
+R.forEach(x => _window[x] = window[x], R.keys(R).filter(k => k in window))
+R.forEach(x => window[x] = R[x], R.keys(R))


### PR DESCRIPTION
window/ramda function collisions are stashed in a preservation object: _window
